### PR TITLE
Add package scripts for building on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
   "scripts": {
     "test": "mocha && eslint lib/**",
     "build": "gulp",
-    "start": "./bin/slackin"
+    "start": "./bin/slackin",
+    "heroku-prebuild": "npm install --only=dev",
+    "heroku-postbuild": "gulp"
   },
   "now": {
     "type": "npm",


### PR DESCRIPTION
Heroku builds dynos from source from scratch (at least, if you use the Heroku button from the readme). But to build from source, you need to install the dev npm dependencies (which Heroku doesn't do by default) and run `gulp`.

This adds the required `package.json` script steps so Heroku builds from source work again, same as the base [slackin project](https://github.com/rauchg/slackin).

Fixes #2