### PR TITLE
Check API response for error before 429 check

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -69,14 +69,14 @@ export default class SlackData extends EventEmitter {
   }
 
   onres(err, res) {
-    // Too Many Requests
-    if (res.status === 429) {
-      return this.retry(res.headers['retry-after'] * 1000);
-    }
-
     if (err) {
       this.emit('error', err);
       return this.retry();
+    }
+
+    // Too Many Requests
+    if (res.status === 429) {
+      return this.retry(res.headers['retry-after'] * 1000);
     }
 
     let users = res.body.members;


### PR DESCRIPTION
Simple code ordering switch. The Slack API HTTP response
was previously checked for a 429 - Too Many Requests status, before
checking if the request itself errored. This caused a crash when the
response was not set.

```
TypeError: Cannot read property 'status' of undefined
    at SlackData.onres (/srv/www/node_modules/slackin-extended/dist/slack.js:105:15)
    at /srv/www/node_modules/slackin-extended/dist/slack.js:83:16
```