### PR TITLE
Loosely check for CoC acceptance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ export default function slackin({
       errorMessage = 'Invalid email';
     } else if (emails && !match.any(email, acceptedEmails)) {
       errorMessage = 'Your email is not on the accepted list.';
-    } else if (coc && req.body.coc !== '1') {
+    } else if (coc && req.body.coc != 1) {
       errorMessage = 'Agreement to CoC is mandatory';
     }
     if (errorMessage) {


### PR DESCRIPTION
This fixes Issue #14. Previously, an accepted state would have `req.body.coc` set to the number `1` and strict equality checking would fail because the code was checking for the string `'1'`. This fixes the issue by having the check allow for type juggling instead, but also checks for the number `1`