### PR TITLE
Procfile: use npm start

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/slackin --coc "$SLACKIN_COC" --channels "$SLACKIN_CHANNELS" $SLACK_SUBDOMAIN $SLACK_API_TOKEN
+web: npm start -- --coc "$SLACKIN_COC" --channels "$SLACKIN_CHANNELS" $SLACK_SUBDOMAIN $SLACK_API_TOKEN


### PR DESCRIPTION
This is so that we reduce duplication. This could probably be applied in the other deployment methods, but since I'm not using them, I'll leave it for someone else.