### PR TITLE
Update nock to v11.5.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -844,20 +844,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
-      "dev": true,
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2158,12 +2144,6 @@
         }
       }
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2964,20 +2944,17 @@
       "dev": true
     },
     "nock": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.5.0.tgz",
+      "integrity": "sha512-gddqQKCzc2JM9WdNcAzuXNnYfc3S8eEG/3a4vqGRjA86glaKuWTVCRWwCaP2ZYdmPcaxy8uPgoEOKz7n/YreFA==",
       "dev": true,
       "requires": {
         "chai": "^4.1.2",
         "debug": "^4.1.0",
-        "deep-equal": "^1.0.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.13",
         "mkdirp": "^0.5.0",
-        "propagate": "^1.0.0",
-        "qs": "^6.5.1",
-        "semver": "^5.5.0"
+        "propagate": "^2.0.0"
       }
     },
     "node-environment-flags": {
@@ -3176,12 +3153,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
-    },
-    "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
       "dev": true
     },
     "object-keys": {
@@ -3492,9 +3463,9 @@
       }
     },
     "propagate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "proxy-addr": {
@@ -3757,15 +3728,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
     "mocha": "^6.2.2",
-    "nock": "^10.0.6",
+    "nock": "^11.5.0",
     "supertest": "^4.0.2"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,13 @@ describe('slackin', () => {
       nock('https://myorg.slack.com')
         .get('/api/users.list')
         .query({ token: 'mytoken', presence: '1' })
+        .reply(200, {
+          ok: true,
+          members: [{}],
+        });
+
+      nock('https://myorg.slack.com')
+        .get('/api/users.list')
         .query({ token: 'mytoken' })
         .reply(200, {
           ok: true,
@@ -82,6 +89,13 @@ describe('slackin', () => {
       nock('https://myorg.slack.com')
         .get('/api/users.list')
         .query({ token: 'mytoken', presence: '1' })
+        .reply(200, {
+          ok: true,
+          members: [{}],
+        });
+
+      nock('https://myorg.slack.com')
+        .get('/api/users.list')
         .query({ token: 'mytoken' })
         .reply(200, {
           ok: true,


### PR DESCRIPTION
The only nock change that seems to affect us is this

>In Nock 10, duplicate field names provided to the .query() method were
silently ignored. We decided this was probably hiding unintentionally bugs
and causing frustration with users. In Nock 11, attempts to provide query
params more than once will throw a new error
Query parameters have aleady been defined. This could happen by calling
.query() twice, or by calling .query() after specifying a literal query
string via the path.

Maybe we should add a couple of new tests?