### PR TITLE
Add `rel="noopener"` in external links.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -218,7 +218,7 @@ export default function slackin({
       }, (inviteErr) => {
         if (inviteErr) {
           if (inviteErr.message === 'Sending you to Slack...') {
-            return res.status(303).json({ msg: inviteErr.message, redirectUrl: `https://${org}.slack.com` });
+            return res.status(303).json({ msg: inviteErr.message, redirectUrl: `https://${org}.slack.com/` });
           }
           return res.status(400).json({ msg: inviteErr.message });
         }

--- a/views/iframe.pug
+++ b/views/iframe.pug
@@ -1,9 +1,9 @@
 span(class=`slack-button ${large ? ' slack-btn-large' : ''}`)
 
-  a.slack-btn(href='/', target='_blank')
+  a.slack-btn(href='/', rel='noopener', target='_blank')
     span.slack-ico
     span.slack-text Slack
-  a.slack-count(href='/', target='_blank')
+  a.slack-count(href='/', rel='noopener', target='_blank')
     if total
       | #{active ? `${active}/` : ''}#{total}
     else

--- a/views/main.pug
+++ b/views/main.pug
@@ -71,14 +71,14 @@ html(class=`${large ? 'large' : ''} ${iframe ? 'iframe' : ''} theme-${theme.name
           .coc
             label
               input(type='checkbox', name='coc', value='1')
-              | I agree to the #[a(href=coc, target='_blank') Code of Conduct].
+              | I agree to the #[a(href=coc, rel='noopener', target='_blank') Code of Conduct].
 
         button.loading Get my Invite
 
-      p.signin or #[a(href=`https://${org}.slack.com`, target='_top') sign in].
+      p.signin or #[a(href=`https://${org}.slack.com/`, target='_top') sign in].
 
       unless iframe
-        footer powered by #[a(href='https://github.com/emedvedev/slackin-extended', target='_blank') slackin extended]
+        footer powered by #[a(href='https://github.com/emedvedev/slackin-extended', rel='noopener', target='_blank') slackin extended]
 
       script
         | data = {};


### PR DESCRIPTION
See https://developers.google.com/web/tools/lighthouse/audits/noopener

Also, add the trailing slash in the URLs