### PR TITLE
Change `prepublish` to `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "npm run build && npm run lint && npm run mocha",
     "build": "node-sass --output-style compressed --precision 6 scss/ -o assets/",
     "start": "cross-env-shell node ./bin/slackin $SLACK_SUBDOMAIN $SLACK_API_TOKEN --coc \\\"$SLACKIN_COC\\\" --channels \\\"$SLACKIN_CHANNELS\\\"",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
`prepublish` runs on `npm i` too. My intention was to run this before publishing only

See https://docs.npmjs.com/misc/scripts#prepublish-and-prepare