### PR TITLE
Update socket.io to v1.7.4 slim.

### DIFF
--- a/assets/iframe.js
+++ b/assets/iframe.js
@@ -47,7 +47,7 @@
 
   // initialize realtime events asynchronously
   var script = document.createElement('script')
-  script.src = 'https://cdn.socket.io/socket.io-1.4.4.js'
+  script.src = 'https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.4/socket.io.slim.min.js'
   script.onload = function () {
     // use dom element for better cross browser compatibility
     var url = document.createElement('a')

--- a/views/main.pug
+++ b/views/main.pug
@@ -94,6 +94,6 @@ html(lang='en', class=`${large ? 'large' : ''}${iframe ? 'iframe' : ''} theme-${
         | }
 
       script(src='https://www.google.com/recaptcha/api.js', async, defer)
-      script(src='https://cdn.socket.io/socket.io-1.4.4.js')
+      script(src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.4/socket.io.slim.min.js')
       script(src=`${path}assets/superagent.js`)
       script(src=`${path}assets/client.js`)


### PR DESCRIPTION
Should be "safe" since it's 1.x. I also switched to the slim version, since I don't think we care about IE < 9 or 10, or browsers without JSON support. Saves ~10 KB compressed.

Refs #100 