### PR TITLE
Implement pagination on the user list

### DIFF
--- a/bin/slackin
+++ b/bin/slackin
@@ -100,6 +100,7 @@ flags.recaptcha = {
 };
 
 // Advanced parameters (env-only)
+flags.pageDelay = process.env.SLACKIN_PAGE_DELAY;
 flags.proxy = Boolean(process.env.SLACKIN_PROXY);
 flags.redirectFQDN = process.env.SLACKIN_HTTPS_REDIRECT;
 flags.letsencrypt = process.env.SLACKIN_LETSENCRYPT;

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ function slackin({
   emails,
   coc,
   proxy,
+  pageDelay = 0,
   redirectFQDN,
   letsencrypt,
   silent,
@@ -140,6 +141,8 @@ function slackin({
     token,
     interval,
     org,
+    pageDelay,
+    fetchChannels: Boolean(channels),
     logger: slackLog,
   });
   slack.setMaxListeners(Infinity);

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -1,14 +1,20 @@
 const { EventEmitter } = require('events');
 const request = require('superagent');
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 class SlackData extends EventEmitter {
   constructor({
-    token, interval, logger, org: host,
+    token, interval, logger, pageDelay, fetchChannels, org: host,
   }) {
     super();
     this.host = host;
     this.token = token;
     this.interval = interval;
+    this.pageDelay = pageDelay;
+    this.fetchChannels = fetchChannels;
     this.ready = false;
     this.org = {};
     this.users = {};
@@ -17,22 +23,10 @@ class SlackData extends EventEmitter {
       this.bindLogs(logger);
     }
     this.init();
-    this.fetch();
+    this.fetchUserCount();
   }
 
-  init() {
-    request
-      .get(`https://${this.host}.slack.com/api/channels.list`)
-      .query({ token: this.token })
-      .end((err, res) => {
-        if (err) {
-          throw err;
-        }
-        (res.body.channels || []).forEach((channel) => {
-          this.channelsByName[channel.name] = channel;
-        });
-      });
-
+  async init() {
     request
       .get(`https://${this.host}.slack.com/api/team.info`)
       .query({ token: this.token })
@@ -47,29 +41,59 @@ class SlackData extends EventEmitter {
           this.org.logo = team.icon.image_132;
         }
       });
+
+    if (this.fetchChannels) {
+      let cursor = '';
+      do {
+        let response = null;
+        response = await request // eslint-disable-line no-await-in-loop
+          .get(`https://${this.host}.slack.com/api/conversations.list`)
+          .query({
+            token: this.token, limit: 800, cursor,
+          });
+        if (response.ok === false && !response.body.channels) {
+          throw new Error(`Error: ${response.error} (status ${response.status})`);
+        }
+        (response.body.channels || []).forEach((channel) => {
+          this.channelsByName[channel.name] = channel;
+        });
+        cursor = response.body.response_metadata.next_cursor;
+        if (cursor && this.pageDelay) {
+          await sleep(this.pageDelay); // eslint-disable-line no-await-in-loop
+        }
+      }
+      while (cursor);
+    }
   }
 
-  async fetch() {
+  async fetchUserCount() {
     let users = [];
     let cursor = '';
-
-    this.emit('fetch');
-
     do {
       let response = null;
-      try {
-        response = await request // eslint-disable-line no-await-in-loop
-          .get(`https://${this.host}.slack.com/api/users.list`)
-          .query({
-            token: this.token, limit: 200, cursor, presence: 1,
-          });
-      } catch (err) {
-        this.emit('error', err);
-        return this.retry();
+      let retryCurrentRequest = false;
+
+      do {
+        try {
+          this.emit('fetch');
+          response = await request // eslint-disable-line no-await-in-loop
+            .get(`https://${this.host}.slack.com/api/users.list`)
+            .query({
+              token: this.token, limit: 800, cursor, presence: 1,
+            });
+        } catch (err) {
+          this.emit('error', err);
+          if (err.response.status === 429) {
+            this.emit('error', `Rate limiting, retrying after ${err.response.headers['retry-after']}`);
+            await this.sleep(err.response.headers['retry-after'] * 1000); // eslint-disable-line no-await-in-loop
+            retryCurrentRequest = true;
+          } else {
+            return this.retry();
+          }
+        }
       }
-      if (response.status === 429) {
-        return this.retry(response.headers['retry-after'] * 1000);
-      }
+      while (retryCurrentRequest);
+
       if (response.ok === false) {
         this.emit('error', new Error(`Slack API error: ${response.error}`));
         return this.retry();
@@ -80,8 +104,11 @@ class SlackData extends EventEmitter {
       }
       users = users.concat(response.body.members);
       cursor = response.body.response_metadata.next_cursor;
+      if (cursor && this.pageDelay) {
+        await sleep(this.pageDelay); // eslint-disable-line no-await-in-loop
+      }
     }
-    while (cursor !== '');
+    while (cursor);
 
     // remove slackbot and bots from users
     // slackbot is not a bot, go figure!
@@ -107,7 +134,7 @@ class SlackData extends EventEmitter {
       this.emit('ready');
     }
 
-    setTimeout(this.fetch.bind(this), this.interval);
+    setTimeout(this.fetchUserCount.bind(this), this.interval);
     return this.emit('data');
   }
 
@@ -117,8 +144,8 @@ class SlackData extends EventEmitter {
   }
 
   retry(delay = this.interval * 2) {
-    setTimeout(this.fetch.bind(this), delay);
-    this.emit('retry');
+    setTimeout(this.fetchUserCount.bind(this), delay);
+    return this.emit('retry');
   }
 
   bindLogs(logger) {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -51,13 +51,11 @@ class SlackData extends EventEmitter {
 
   async fetch() {
     let users = [];
-    let firstPage = true;
     let cursor = '';
 
     this.emit('fetch');
 
     do {
-      firstPage = false;
       let response = null;
       try {
         response = await request // eslint-disable-line no-await-in-loop
@@ -83,7 +81,7 @@ class SlackData extends EventEmitter {
       users = users.concat(response.body.members);
       cursor = response.body.response_metadata.next_cursor;
     }
-    while (firstPage === true || cursor !== '');
+    while (cursor !== '');
 
     // remove slackbot and bots from users
     // slackbot is not a bot, go figure!

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -49,43 +49,37 @@ class SlackData extends EventEmitter {
       });
   }
 
-  fetch() {
-    request
-      .get(`https://${this.host}.slack.com/api/users.list`)
-      .query({ token: this.token, presence: 1 })
-      .end((err, res) => {
-        this.onres(err, res);
-      });
+  async fetch() {
+    let users = [];
+    let firstPage = true;
+    let cursor = '';
+
     this.emit('fetch');
-  }
 
-  getChannelId(name) {
-    const channel = this.channelsByName[name];
-    return channel ? channel.id : null;
-  }
-
-  retry(delay = this.interval * 2) {
-    setTimeout(this.fetch.bind(this), delay);
-    this.emit('retry');
-  }
-
-  onres(err, res) {
-    if (err) {
-      this.emit('error', err);
-      return this.retry();
+    do {
+      firstPage = false;
+      let response = null;
+      try {
+        response = await request // eslint-disable-line no-await-in-loop
+          .get(`https://${this.host}.slack.com/api/users.list`)
+          .query({
+            token: this.token, limit: 200, cursor, presence: 1,
+          });
+      } catch (err) {
+        this.emit('error', err);
+        return this.retry();
+      }
+      if (response.status === 429) {
+        return this.retry(response.headers['retry-after'] * 1000);
+      }
+      if (!response.body.members) {
+        this.emit('error', new Error(`Invalid Slack response: ${response.status}`));
+        return this.retry();
+      }
+      users = users.concat(response.body.members);
+      cursor = response.body.response_metadata.next_cursor;
     }
-
-    // Too Many Requests
-    if (res.status === 429) {
-      return this.retry(res.headers['retry-after'] * 1000);
-    }
-
-    let users = res.body.members;
-
-    if (!users || !users.length) {
-      this.emit('error', new Error(`Invalid Slack response: ${res.status}`));
-      return this.retry();
-    }
+    while (firstPage === true || cursor !== '');
 
     // remove slackbot and bots from users
     // slackbot is not a bot, go figure!
@@ -113,6 +107,16 @@ class SlackData extends EventEmitter {
 
     setTimeout(this.fetch.bind(this), this.interval);
     return this.emit('data');
+  }
+
+  getChannelId(name) {
+    const channel = this.channelsByName[name];
+    return channel ? channel.id : null;
+  }
+
+  retry(delay = this.interval * 2) {
+    setTimeout(this.fetch.bind(this), delay);
+    this.emit('retry');
   }
 
   bindLogs(logger) {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -72,6 +72,10 @@ class SlackData extends EventEmitter {
       if (response.status === 429) {
         return this.retry(response.headers['retry-after'] * 1000);
       }
+      if (response.ok === false) {
+        this.emit('error', new Error(`Slack API error: ${response.error}`));
+        return this.retry();
+      }
       if (!response.body.members) {
         this.emit('error', new Error(`Invalid Slack response: ${response.status}`));
         return this.retry();

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Every CLI parameter, including mandatory arguments (workspace ID and token), can
 | --accent | -A | `SLACKIN_ACCENT` | `#e01563` for `light`, `#9a0e44` for `dark` | Accent color to use instead of a theme default |
 | --coc | -C | `SLACKIN_COC` | `''` | Full URL to a CoC that needs to be agreed to |
 | --css | -S | `SLACKIN_CSS` | `''` | Full URL to a custom CSS file to use on the main page |
+| | | `SLACKIN_PAGE_DELAY` | `0` | Delay (ms) between Slack API requests (may be required for large workspaces that hit the rate limit) |
 | | | `SLACKIN_PROXY` | `false` | Trust proxy headers (only use if Slackin is served behind a reverse proxy) |
 | | | `SLACKIN_HTTPS_REDIRECT` | `''` | If a domain name is specified in this parameter and `SLACKIN_PROXY` is set to `true`, Slackin will redirect requests with `x-forwarded-proto === 'http'` to `https://<SLACKIN_HTTPS_REDIRECT>/<original URL>` |
 | | | `SLACKIN_LETSENCRYPT` | `''` | [Let's Encrypt](https://letsencrypt.org/) challenge response |

--- a/test/index.js
+++ b/test/index.js
@@ -7,18 +7,22 @@ describe('slackin', () => {
     beforeEach(() => {
       nock('https://myorg.slack.com')
         .get('/api/users.list')
-        .query({ token: 'mytoken', presence: '1' })
+        .query({
+          token: 'mytoken', presence: '1', limit: 200, cursor: '',
+        })
         .reply(200, {
           ok: true,
           members: [{}],
+          response_metadata: { next_cursor: '' },
         });
 
       nock('https://myorg.slack.com')
         .get('/api/users.list')
-        .query({ token: 'mytoken' })
+        .query({ token: 'mytoken', limit: 200, cursor: '' })
         .reply(200, {
           ok: true,
           members: [{}],
+          response_metadata: { next_cursor: '' },
         });
 
       nock('https://myorg.slack.com')

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ describe('slackin', () => {
       nock('https://myorg.slack.com')
         .get('/api/users.list')
         .query({
-          token: 'mytoken', presence: '1', limit: 200, cursor: '',
+          token: 'mytoken', presence: '1', limit: 800, cursor: '',
         })
         .reply(200, {
           ok: true,
@@ -18,7 +18,7 @@ describe('slackin', () => {
 
       nock('https://myorg.slack.com')
         .get('/api/users.list')
-        .query({ token: 'mytoken', limit: 200, cursor: '' })
+        .query({ token: 'mytoken', limit: 800, cursor: '' })
         .reply(200, {
           ok: true,
           members: [{}],
@@ -26,7 +26,7 @@ describe('slackin', () => {
         });
 
       nock('https://myorg.slack.com')
-        .get('/api/channels.list?token=mytoken')
+        .get('/api/conversations.list?token=mytoken')
         .reply(200, {
           ok: true,
           channels: [{}],


### PR DESCRIPTION
Fixes #20

@XhmikosR sorry for such a delay! But I'm finally ready to get back to this :)

This PR implements cursor-based pagination on the user list, and while it's not perfect yet, should already work. 

To do:
- [x] Retry a specific page on a rate limiting event, not the entire thing (which is probably useless).
- [x] Implement the same for the channel list (would anyone even need pagination for the channel list though?)
- [x] Handle `{"ok": false}` responses as errors.
- [x] Make delay between pages configurable