### PR TITLE
fixup panics and properly redirect to slack server

### DIFF
--- a/assets/client.js
+++ b/assets/client.js
@@ -52,15 +52,18 @@ function invite(chan, coc, email, gcaptcha_response_value, fn) {
       email: email
     })
     .end(function (res) {
-      if (res.body.redirectUrl) {
+      if (res && res.response) {
+        res = res.response
+      }
+      if (res && res.body && res.body.redirectUrl) {
         window.setTimeout(function () {
           topLevelRedirect(res.body.redirectUrl)
         }, 1500)
       }
-      if (res.error) {
+      if (res && res.error) {
         return fn(new Error(res.body.msg || 'Server error'))
       }
-      fn(null, res.body.msg)
+      fn(null, 'Invite sent')
     })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,9 +237,15 @@ function slackin({
               redirectUrl: `https://${org}.slack.com/`,
             });
           }
-          return res.status(400).json({ msg: inviteErr.message });
+          return res.status(400).json({
+            msg: inviteErr.message,
+            redirectUrl: `https://${org}.slack.com/`,
+          });
         }
-        return res.status(200).json({ msg: 'WOOT. Check your email!' });
+        return res.status(200).json({
+          msg: 'WOOT. Check your email!',
+          redirectUrl: `https://${org}.slack.com/`,
+        });
       });
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -57,9 +57,9 @@ describe('slackin', () => {
         .post('/invite')
         .send({ email: 'foo@example.com' })
         .expect('Content-Type', /json/)
-        .expect(200, { 
+        .expect(200, {
           msg: 'WOOT. Check your email!',
-          redirectUrl: 'https://myorg.slack.com/'
+          redirectUrl: 'https://myorg.slack.com/',
         })
         .end(done);
     });
@@ -84,9 +84,9 @@ describe('slackin', () => {
         .post('/invite')
         .send({ email: 'foo@example.com' })
         .expect('Content-Type', /json/)
-        .expect(400, { 
+        .expect(400, {
           msg: 'other error',
-          redirectUrl: 'https://myorg.slack.com/'
+          redirectUrl: 'https://myorg.slack.com/',
         })
         .end(done);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -57,7 +57,10 @@ describe('slackin', () => {
         .post('/invite')
         .send({ email: 'foo@example.com' })
         .expect('Content-Type', /json/)
-        .expect(200, { msg: 'WOOT. Check your email!' })
+        .expect(200, { 
+          msg: 'WOOT. Check your email!',
+          redirectUrl: 'https://myorg.slack.com/'
+        })
         .end(done);
     });
 
@@ -81,7 +84,10 @@ describe('slackin', () => {
         .post('/invite')
         .send({ email: 'foo@example.com' })
         .expect('Content-Type', /json/)
-        .expect(400, { msg: 'other error' })
+        .expect(400, { 
+          msg: 'other error',
+          redirectUrl: 'https://myorg.slack.com/'
+        })
         .end(done);
     });
   });


### PR DESCRIPTION
I ran into some "cannot read property" from signing up with a slack invite. This change works for me to redirect and not panic on `slack.moov.io`.