### PR TITLE
Tweaks

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,5 +1,4 @@
 {
-  "name": "slackin-extended",
   "version": 2,
   "env": {
     "SLACK_SUBDOMAIN": "@slack-subdomain",

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,8 @@ Set up [Now](https://zeit.co/now) on your device and run it! If you don't have a
 
 ```bash
 git clone https://github.com/emedvedev/slackin-extended.git
-now secrets add @slack-subdomain "myslack"
-now secrets add @slack-api-token "xoxb-YOUR-SLACK-TOKEN"
+now secrets add slack-subdomain "myslack"
+now secrets add slack-api-token "xoxb-YOUR-SLACK-TOKEN"
 now slackin-extended
 ```
 


### PR DESCRIPTION
Hi, thank you for good project. 
I succeed to make my slack public channel.
On the way, I found few things which to be fixed

1. Remove name property, cuz deprecated.

```sh
$ now slackin-extended
Now CLI 17.0.4
❗️  The `name` property in now.json is deprecated (https://zeit.ink/5F)
```

2. Fix now secrets command of readme.md to fix this error.

```sh
~/.g/g/emedvedev now secrets add @slack-subdomain "mysubdomain"
Now CLI 17.0.4
Error! Only alphanumerics and `. _ -` are allowed as `name`
```

Glad to review it, thanks!
