### PR TITLE
Fix TypeError `this.sleep` is not a function.

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -88,7 +88,7 @@ class SlackData extends EventEmitter {
           this.emit('error', error);
           if (error.response.status === 429) {
             this.emit('error', `Rate limiting, retrying after ${error.response.headers['retry-after']}`);
-            await this.sleep(error.response.headers['retry-after'] * 1000); // eslint-disable-line no-await-in-loop
+            await sleep(error.response.headers['retry-after'] * 1000); // eslint-disable-line no-await-in-loop
             retryCurrentRequest = true;
           } else {
             return this.retry();


### PR DESCRIPTION
@emedvedev this is untested, but `sleep()` does not appear to be part of the Class hence one of the errors I get in #193.

Fixes #193