### PR TITLE
badge: make `rect` and `path` self-closing

### DIFF
--- a/views/badge-svg.pug
+++ b/views/badge-svg.pug
@@ -10,10 +10,10 @@
 
 svg(xmlns='http://www.w3.org/2000/svg', width=tw, height='20')
 
-  rect(rx='3', height='20', width=tw, fill='#555')
-  rect(rx='3', height='20', width=rw, fill=bg, x=lw)
+  rect(rx='3', height='20', width=tw, fill='#555')/
+  rect(rx='3', height='20', width=rw, fill=bg, x=lw)/
 
-  path(d=`M${lw} 0h${sep}v20h-${sep}z`, fill=bg)
+  path(d=`M${lw} 0h${sep}v20h-${sep}z`, fill=bg)/
 
   g(text-anchor='middle', font-family='DejaVu Sans, Verdana, Geneva, sans-serif', font-size='11')
 


### PR DESCRIPTION
Pug doesn't do that in this template because the doctype isn't xml. But adding an explicit xml doctype would output the xml tag too, which is valid, but it's redundant.

This saves a few bytes from the rendered badge.