### PR TITLE
Update to Node.js 14.x.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:14-alpine
 ADD . /srv/www
 WORKDIR /srv/www
 RUN npm install --unsafe-perm

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -99,8 +99,7 @@
             "SLACK_SUBDOMAIN": "[parameters('slackTeamId')]",
             "SLACK_API_TOKEN": "[parameters('slackApiToken')]",
             "SLACKIN_RELEASE": "[parameters('slackinRelease')]",
-            "WEBSITE_NPM_DEFAULT_VERSION": "6.4.1",
-            "WEBSITE_NODE_DEFAULT_VERSION": "10.15.2",
+            "WEBSITE_NODE_DEFAULT_VERSION": "~14",
             "command": "bash scripts/azuredeploy.sh"
           }
         },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "xo": "^0.37.1"
   },
   "engines": {
-    "node": "10.x"
+    "node": "14.x"
   },
   "scripts": {
     "dev": "nodemon --watch assets/ --watch lib/ --watch scss/ --ext js,scss,svg --exec \"npm-run-all build start\"",


### PR DESCRIPTION
@emedvedev I can only test Heroku.

That being said, I checked the Azure docs https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_node_default_version, and it seems we can use `~14`. Also, not sure if we need to specify an npm version explicitly so I removed it.

Please test a deployment on Azure, or if you can't, let's add back the npm version (not sure which version it should be exactly). Do note that I personally don't suggest pinning the versions like that because of security issues. It's better to use semver.

Fixes #195 