### PR TITLE
Revert "Bump hostenv from 3.13.0 to 3.15.0 (#266)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3894,9 +3894,9 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "hostenv": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/hostenv/-/hostenv-3.15.0.tgz",
-      "integrity": "sha512-J4BlGyT8rAziqzkxeemf4C0qp4pLUbsl/P5qIQTu0UfW6XSEObna/ivJBR1Q5XO2ClahZ8S8OJ9aRppjRCSj/w=="
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/hostenv/-/hostenv-3.13.0.tgz",
+      "integrity": "sha512-Z65htLA+fsmQKvbb2jlPS6e6oG5njfSpnvJT6fE8EwsB726KJVkJEWp1Hne8G7acAG06i/wO2TyqWz4mhvbgHw=="
     },
     "html-tags": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email-regex": "^4.0.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "hostenv": "3.15.0",
+    "hostenv": "3.13.0",
     "micromatch": "^4.0.2",
     "morgan": "^1.10.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This reverts commit f57e7185cf999de80e16e3353878011609037d1a.

Breaks deployments on Heroku.