### PR TITLE
Add a Privacy Policy option

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,6 +29,10 @@
       "description": "A URL to a Code of Conduct people must agree on before joining.",
       "required": false
     },
+    "SLACK_PRIVACY": {
+       "description": "A URL to a privacy policy people must agree on before joining.",
+       "required": false
+     },
     "SLACKIN_CHANNELS": {
       "description": "Comma-separated list of single guest channels to invite them to (leave blank for a normal, all-channel invite). In order to make this work, you have to have a paid account. You'll only be able to invite as many people as your number of paying members times 5.",
       "required": false

--- a/assets/badge.js
+++ b/assets/badge.js
@@ -111,7 +111,7 @@
     div.style.lineHeight = '0'
     div.style.backgroundColor = '#fafafa'
     div.style.width = '25em'
-    div.style.height = '15.5em'
+    div.style.height = '30em'
     div.style.position = 'absolute'
     div.style.left = '-10000px'
     div.style.top = '-10000px'
@@ -123,7 +123,7 @@
     var ni = document.createElement('iframe')
     ni.className = '__slackin'
     ni.style.width = '25em'
-    ni.style.height = '15.5em'
+    ni.style.height = '30em'
     ni.style.borderWidth = 0
     ni.src = iframe.src.replace('iframe', 'iframe/dialog')
     ni.addEventListener('load', function () {

--- a/assets/client.js
+++ b/assets/client.js
@@ -8,6 +8,7 @@ var form = body.querySelector('form#invite')
 var channel = form.elements.channel || {}
 var email = form.elements.email
 var coc = form.elements.coc
+var privacy = form.elements.privacy
 var button = body.querySelector('button')
 
 // remove loading state
@@ -28,7 +29,7 @@ function submitForm(ev) {
     return grecaptcha.execute()
   }
 
-  invite(channel ? channel.value : null, coc && coc.checked ? 1 : 0, email.value, gcaptcha_token, function (err, msg) {
+  invite(channel ? channel.value : null, coc && coc.checked ? 1 : 0, privacy && privacy.checked ? 1 : 0, email.value, gcaptcha_token, function (err, msg) {
     if (err) {
       button.removeAttribute('disabled')
       button.classList.add('error')
@@ -42,12 +43,13 @@ function submitForm(ev) {
 
 body.addEventListener('submit', submitForm)
 
-function invite(chan, coc, email, gcaptcha_response_value, fn) {
+function invite(chan, coc, privacy, email, gcaptcha_response_value, fn) {
   request
     .post(data.path + 'invite')
     .send({
       'g-recaptcha-response': gcaptcha_response_value,
       coc: coc,
+      privacy: privacy,
       channel: chan,
       email: email
     })

--- a/bin/slackin.js
+++ b/bin/slackin.js
@@ -74,6 +74,10 @@ args
     process.env.SLACKIN_COC,
   )
   .option(
+    ['O', 'privacy'], 'Full URL to a privacy policy that must be agreed to',
+    process.env.SLACKIN_PRIVACY,
+  )
+  .option(
     ['S', 'css'], 'Full URL to a custom CSS file to use on the main page',
     process.env.SLACKIN_CSS,
   )

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ function slackin({
   channels,
   emails,
   coc,
+  privacy,
   proxy,
   pageDelay = 0,
   redirectFQDN,
@@ -182,6 +183,7 @@ function slackin({
       .type('html')
       .render('main', {
         coc,
+        privacy,
         path: relativePath,
         name,
         org,
@@ -204,6 +206,7 @@ function slackin({
       name,
       org,
       coc,
+      privacy,
       logo,
       active,
       total,
@@ -231,6 +234,8 @@ function slackin({
       errorMessage = 'Your email is not on the accepted list.';
     } else if (coc && Number(req.body.coc) !== 1) {
       errorMessage = 'Agreement to CoC is mandatory';
+    } else if (privacy && Number(req.body.privacy) !== 1) {
+      errorMessage = 'Agreement to the Privacy Policy is mandatory';
     }
 
     if (errorMessage) {
@@ -317,6 +322,7 @@ function slackin({
     res.type('html');
     res.render('main', {
       coc,
+      privacy,
       path: relativePath,
       name,
       org,

--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -84,7 +84,8 @@ body {
   }
 }
 
-.coc {
+.coc,
+.privacy {
   font-size: 1.2rem;
   padding: 1.5rem 0 .5rem;
   color: #666;
@@ -125,12 +126,14 @@ body {
 }
 
 html.iframe {
-  .coc {
+  .coc,
+  .privacy {
     font-size: 1.1rem;
     padding-top: 1rem;
   }
 
-  .coc input {
+  .coc input,
+  .privacy input {
     position: relative;
     top: -.2rem;
   }

--- a/scss/_dark.scss
+++ b/scss/_dark.scss
@@ -47,6 +47,10 @@ html.theme-dark {
     darken($foreground, 20),
     // $color-coc-link:
     darken($foreground, 20),
+    // $color-privacy:
+    darken($foreground, 20),
+    // $color-privacy-link:
+    darken($foreground, 20),
     // $color-button-text:
     $button-text,
     // $color-button-background:

--- a/scss/_light.scss
+++ b/scss/_light.scss
@@ -37,6 +37,10 @@ html.theme-light {
     lighten($foreground, 40),
     // $color-coc-link:
     lighten($foreground, 40),
+    // $color-privacy:
+    lighten($foreground, 40),
+    // $color-privacy-link:
+    lighten($foreground, 40),
     // $color-button-text:
     $button-text,
     // $color-button-background:

--- a/scss/_mixin.scss
+++ b/scss/_mixin.scss
@@ -9,6 +9,8 @@
   $color-signin-link,
   $color-coc,
   $color-coc-link,
+  $color-privacy,
+  $color-privacy-link,
   $color-button-text,
   $color-button-background,
   $color-button-success-text,
@@ -48,6 +50,20 @@
 
       &:hover {
         background-color: $color-coc-link;
+        color: $color-background;
+      }
+    }
+  }
+
+  // Privacy Policy:
+  .privacy {
+    color: $color-privacy;
+
+    a {
+      color: $color-privacy-link;
+
+      &:hover {
+        background-color: $color-privacy-link;
         color: $color-background;
       }
     }

--- a/views/main.pug
+++ b/views/main.pug
@@ -79,6 +79,12 @@ html(lang='en', class=`${large ? 'large' : ''}${iframe ? 'iframe' : ''} theme-${
               input(type='checkbox', name='coc', value='1', required)
               | I agree to the #[a(href=coc, rel='noopener', target='_blank') Code of Conduct].
 
+        if privacy
+          .privacy
+            label
+              input(type='checkbox', name='privacy', value='1', required)
+              | I agree to the #[a(href=privacy, rel='noopener', target='_blank') Privacy Policy].
+
         button.loading Get my Invite
 
       p.signin or #[a(href=`https://${org}.slack.com/`, target='_top') sign in].


### PR DESCRIPTION
This allows you to require users accept the Privacy Policy as well as
the Code of Conduct before receiving an invite. This is important,
especially if you do business governed by GDPR, CCPA, or the like.

See an example running on https://slack.puppet.com