### PR TITLE
Add GHCR image

### DIFF
--- a/.github/workflows/build_push_ghcr.yaml
+++ b/.github/workflows/build_push_ghcr.yaml
@@ -1,0 +1,34 @@
+name: Build container image for GHCR
+on:
+  push: {}
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Build branch images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for container image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value={{branch}}
+
+      - name: Build and push container image to GHCR
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add GHA workflow to build and publish a container image to GHCR. Particularly useful for easily deploying to k8s with latest code.