### PR TITLE
Fix: reset retry state flag in fetch user count logic

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -80,6 +80,7 @@ class SlackData extends EventEmitter {
 
       do {
         try {
+          retryCurrentRequest = false;
           this.emit('fetch');
           response = await this.getUsersList(cursor); // eslint-disable-line no-await-in-loop
         } catch (error) {


### PR DESCRIPTION
Resetting the `retryCurrentRequest` variable in `SlackData.fetchUserCount` before making a request. This part of the code was getting stuck in an infinite loop due to the flag never being set back to `false`.